### PR TITLE
set global default for docker service restart policy to default with fallback

### DIFF
--- a/compose.production.yml
+++ b/compose.production.yml
@@ -1,3 +1,7 @@
+x-restart: &restart
+  restart: unless-stopped
+
 services:
   rabbit-mq-app:
+    <<: *restart
     image: ghcr.io/tecsafe/rabbit-mq:main-7aaed00

--- a/compose.yml
+++ b/compose.yml
@@ -1,9 +1,5 @@
-x-restart: &restart
-  restart: ${RESTART_POLICY:-unless-stopped}
-
 services:
   rabbit-mq-app:
-    <<: *restart
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 30s

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,9 @@
+x-restart: &restart
+  restart: ${RESTART_POLICY:-unless-stopped}
+
 services:
   rabbit-mq-app:
-    restart: unless-stopped
+    <<: *restart
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 30s


### PR DESCRIPTION
set global default for docker service restart policy to default unless-stopped and can be overwritten with the ENV RESTART_POLICY